### PR TITLE
fgwrite: Fix definition of card size

### DIFF
--- a/src/fgwrite.c
+++ b/src/fgwrite.c
@@ -127,7 +127,7 @@ char	*argv[];
 	static	char	*def_flist[1] = {NULL};
 	char	*argp, **flist, *arg, *ip;
 	pointer kwdb, kwtoc;
-	char    card[256];
+	char    card[SZ_PATHNAME];
 	char    *sline;
 	int	argno, ftype, i, ncards, level, phu;
 


### PR DESCRIPTION
The `card` string is used in a [`getcwd(card, SZ_PATHNAME)`](https://github.com/iraf/extpkg-fitsutil/blob/eb6995bdfc3fb31f1a02c5351c823fc78c721736/src/fgwrite.c#L261) call. The man page of [getcwd (3)](https://manpages.debian.org/stretch/manpages-dev/getcwd.2.en.html) says:

>     char *getcwd(char *buf, size_t size);
> [...] The size argument is the size in bytes of the character array pointed to by the buf argument.

`SZ_PATHNAME` is set to 511; however `card` had only 256 chars. With hardening enabled, this resulted in a segmentation fault on Debian.

This PR just increases the size of `card` to the necessary value.